### PR TITLE
Specify LDFLAGS on osx for gfortran

### DIFF
--- a/pyspharm/build.sh
+++ b/pyspharm/build.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
-python setup.py install <<"EOF"
+# Modify flags for build on osx
+if [ `uname` == Darwin ]; then
+    export LDFLAGS="-m64 -Wall -g -undefined dynamic_lookup -bundle"
+fi
+
+$PYTHON setup.py install <<"EOF"
 yes
 EOF


### PR DESCRIPTION
This was the easiest way to get the linker to succeed on OS X; for whatever reason, installing from source/pypi propagated the correct linker flags with gfortran, but conda failed to do so. So this sets them manually. Alternative solution would be to link to someone's gcc/gfortran conda package, but I don't think there is a reliable one for OS X yet.

Tested with Python 2.7/3.4, on two different machines - vanilla miniconda installs and new environments.
